### PR TITLE
Save settings in EEPROM

### DIFF
--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -141,9 +141,9 @@ static void clocks_store_channel(const struct params* p, struct channel_settings
 /* ------------------------------------------------------------------   */
 void clocks_store(struct settings_data *settings) {
 
-  settings->clk_src = CLK_SRC;
+  settings->clk_src = (uint8_t)CLK_SRC;
   settings->bpm = BPM;
-  settings->bpm_sel = BPM_SEL;
+  settings->bpm_sel = (uint8_t)BPM_SEL;
 
   for (int i  = 0; i < 6; i++) {
     clocks_store_channel(&allChannels[i], &settings->channels[i]);

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -232,7 +232,7 @@ void next_clocks() {
   }
   // next DAC code: 
   if (allChannels[DAC_CHANNEL].mode == DAC) outputDAC(&allChannels[DAC_CHANNEL]);
-  else DAC_OUT = (CLOCKS_STATE & 0x8) ?  DAC_OUT = _ON : DAC_OUT = _ZERO[0];
+  else DAC_OUT = (CLOCKS_STATE & 0x8) ? _ON : _ZERO[0];
 }
 
 /*  --------------------------- the clock modes --------------------------    */

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -112,9 +112,20 @@ void bpm_set_microseconds() {
 }
 
 /* ------------------------------------------------------------------   */
+void channel_set_mode(struct params* p, uint8_t mode) {
+  
+  p->mode = mode;
+  p->mode_param_numbers = _CHANNEL_PARAMS[mode];
+  const uint16_t *_min_ptr = _CHANNEL_PARAMS_MIN[mode];
+  const uint16_t *_max_ptr = _CHANNEL_PARAMS_MAX[mode];
+  memcpy(p->param_min, _min_ptr, sizeof(p->param_min));
+  memcpy(p->param_max, _max_ptr, sizeof(p->param_max));
+}
+
+/* ------------------------------------------------------------------   */
 static void clocks_restore_channel(struct params* p, const struct channel_settings* settings) {
   
-  p->mode = settings->mode;
+  channel_set_mode(p, settings->mode);
   memcpy(p->param[p->mode], settings->param, sizeof(settings->param));
   memcpy(p->cvmod, settings->cvmod, sizeof(p->cvmod));
 }
@@ -168,13 +179,8 @@ void coretimer() {
 
 void init_channel(struct params* _p, uint8_t _channel) {
 
-  _p->mode = INIT_MODE;
+  channel_set_mode(_p, INIT_MODE);
   _p->channel_modes = _CHANNEL_MODES[_channel];
-  _p->mode_param_numbers = _CHANNEL_PARAMS[INIT_MODE];
-  const uint16_t *_min_ptr = _CHANNEL_PARAMS_MIN[INIT_MODE];
-  const uint16_t *_max_ptr = _CHANNEL_PARAMS_MAX[INIT_MODE];
-  memcpy(_p->param_min, _min_ptr, sizeof(_p->param_min));
-  memcpy(_p->param_max, _max_ptr, sizeof(_p->param_max));
   _p->lfsr = random(0xFFFFFFFF);
 
   for (int i = 0; i < MODES; i++) {

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -90,13 +90,7 @@ const uint16_t _CHANNEL_PARAMS_MAX[MODES][4] = {
   {1, 31, 1, 0}
 };
 
-params *channel1, *channel2, *channel3, *channel4, *channel5, *channel6;
-
-params allChannels[6] {
-
-  *channel1, *channel2, *channel3, *channel4, *channel5, *channel6
-
-};
+static params allChannels[6];
 
 /*  -----------------  internal clock -------------------------------  */
 
@@ -111,11 +105,6 @@ void coretimer() {
 }
 
 /* ------------------------------------------------------------------   */
-
-void make_channel(struct params* _p) {
-
-  _p = (params*)malloc(sizeof(params));
-}
 
 void init_channel(struct params* _p, uint8_t _channel) {
 
@@ -150,7 +139,6 @@ void init_clocks() {
 
   for (int i  = 0; i < CHANNELS; i++) {
 
-    make_channel(&allChannels[i]);
     init_channel(&allChannels[i], i);
   }
 }

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -93,32 +93,32 @@ const uint16_t _CHANNEL_PARAMS_MAX[MODES][4] = {
 params allChannels[6];
 
 /* ------------------------------------------------------------------   */
-static void clocks_restore_channel( struct params* _p, const struct channel_settings* _settings ) {
+static void clocks_restore_channel(struct params* _p, const struct channel_settings* _settings) {
   
   _p->mode = _settings->mode;
-  memcpy( _p->param[ _p->mode ], _settings->param, sizeof( _settings->param ) );
-  memcpy( _p->cvmod, _settings->cvmod, sizeof( _p->cvmod ) );
+  memcpy(_p->param[_p->mode], _settings->param, sizeof(_settings->param));
+  memcpy(_p->cvmod, _settings->cvmod, sizeof(_p->cvmod));
 }
 
 /* ------------------------------------------------------------------   */
-static void clocks_store_channel( const struct params* _p, struct channel_settings* _settings ) {
+static void clocks_store_channel(const struct params* _p, struct channel_settings* _settings) {
   
   _settings->mode = _p->mode;
-  memcpy( _settings->param, _p->param[ _p->mode ], sizeof( _settings->param ) );
-  memcpy( _settings->cvmod, _p->cvmod, sizeof( _p->cvmod ) );
+  memcpy(_settings->param, _p->param[_p->mode], sizeof(_settings->param));
+  memcpy(_settings->cvmod, _p->cvmod, sizeof(_p->cvmod));
 }
 
 /* ------------------------------------------------------------------   */
-void clocks_store( struct settings_data *_settings ) {
+void clocks_store(struct settings_data *_settings) {
   for (int i  = 0; i < 6; i++) {
-    clocks_store_channel( &allChannels[i], &_settings->channels[i] );
+    clocks_store_channel(&allChannels[i], &_settings->channels[i]);
   }
 }
 
 /* ------------------------------------------------------------------   */
-void clocks_restore( const struct settings_data *_settings ) {
+void clocks_restore(const struct settings_data *_settings) {
     for (int i  = 0; i < 6; i++) {
-      clocks_restore_channel( &allChannels[i], &_settings->channels[i] );
+      clocks_restore_channel(&allChannels[i], &_settings->channels[i]);
     }
 }
 

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -18,6 +18,14 @@ enum CLOCKMODES {
 
 };
 
+enum _BPM_SEL {
+  
+  _4TH, 
+  _8TH,
+  _16TH
+  
+};
+
 extern const uint32_t BPM_microseconds_4th[];
 extern const uint32_t BPM_microseconds_8th[];
 extern const uint32_t BPM_microseconds_16th[];
@@ -93,33 +101,55 @@ const uint16_t _CHANNEL_PARAMS_MAX[MODES][4] = {
 params allChannels[6];
 
 /* ------------------------------------------------------------------   */
-static void clocks_restore_channel(struct params* _p, const struct channel_settings* _settings) {
-  
-  _p->mode = _settings->mode;
-  memcpy(_p->param[_p->mode], _settings->param, sizeof(_settings->param));
-  memcpy(_p->cvmod, _settings->cvmod, sizeof(_p->cvmod));
-}
+void bpm_set_microseconds() {
+  switch (BPM_SEL) {
 
-/* ------------------------------------------------------------------   */
-static void clocks_store_channel(const struct params* _p, struct channel_settings* _settings) {
-  
-  _settings->mode = _p->mode;
-  memcpy(_settings->param, _p->param[_p->mode], sizeof(_settings->param));
-  memcpy(_settings->cvmod, _p->cvmod, sizeof(_p->cvmod));
-}
-
-/* ------------------------------------------------------------------   */
-void clocks_store(struct settings_data *_settings) {
-  for (int i  = 0; i < 6; i++) {
-    clocks_store_channel(&allChannels[i], &_settings->channels[i]);
+      case _4TH:  BPM_MICROSEC = BPM_microseconds_4th[BPM-BPM_MIN];  break;
+      case _8TH:  BPM_MICROSEC = BPM_microseconds_8th[BPM-BPM_MIN];  break;
+      case _16TH: BPM_MICROSEC = BPM_microseconds_16th[BPM-BPM_MIN]; break;
+      default: break;
   }
 }
 
 /* ------------------------------------------------------------------   */
-void clocks_restore(const struct settings_data *_settings) {
-    for (int i  = 0; i < 6; i++) {
-      clocks_restore_channel(&allChannels[i], &_settings->channels[i]);
-    }
+static void clocks_restore_channel(struct params* p, const struct channel_settings* settings) {
+  
+  p->mode = settings->mode;
+  memcpy(p->param[p->mode], settings->param, sizeof(settings->param));
+  memcpy(p->cvmod, settings->cvmod, sizeof(p->cvmod));
+}
+
+/* ------------------------------------------------------------------   */
+static void clocks_store_channel(const struct params* p, struct channel_settings* settings) {
+  
+  settings->mode = p->mode;
+  memcpy(settings->param, p->param[p->mode], sizeof(settings->param));
+  memcpy(settings->cvmod, p->cvmod, sizeof(p->cvmod));
+}
+
+/* ------------------------------------------------------------------   */
+void clocks_store(struct settings_data *settings) {
+
+  settings->clk_src = CLK_SRC;
+  settings->bpm = BPM;
+  settings->bpm_sel = BPM_SEL;
+
+  for (int i  = 0; i < 6; i++) {
+    clocks_store_channel(&allChannels[i], &settings->channels[i]);
+  }
+}
+
+/* ------------------------------------------------------------------   */
+void clocks_restore(const struct settings_data *settings) {
+  
+  CLK_SRC = settings->clk_src;
+  BPM = settings->bpm;
+  BPM_SEL = settings->bpm_sel;
+  bpm_set_microseconds();
+
+  for (int i  = 0; i < 6; i++) {
+    clocks_restore_channel(&allChannels[i], &settings->channels[i]);
+  }
 }
 
 /*  -----------------  internal clock -------------------------------  */

--- a/soft/temps_utile/clocks.ino
+++ b/soft/temps_utile/clocks.ino
@@ -90,7 +90,37 @@ const uint16_t _CHANNEL_PARAMS_MAX[MODES][4] = {
   {1, 31, 1, 0}
 };
 
-static params allChannels[6];
+params allChannels[6];
+
+/* ------------------------------------------------------------------   */
+static void clocks_restore_channel( struct params* _p, const struct channel_settings* _settings ) {
+  
+  _p->mode = _settings->mode;
+  memcpy( _p->param[ _p->mode ], _settings->param, sizeof( _settings->param ) );
+  memcpy( _p->cvmod, _settings->cvmod, sizeof( _p->cvmod ) );
+}
+
+/* ------------------------------------------------------------------   */
+static void clocks_store_channel( const struct params* _p, struct channel_settings* _settings ) {
+  
+  _settings->mode = _p->mode;
+  memcpy( _settings->param, _p->param[ _p->mode ], sizeof( _settings->param ) );
+  memcpy( _settings->cvmod, _p->cvmod, sizeof( _p->cvmod ) );
+}
+
+/* ------------------------------------------------------------------   */
+void clocks_store( struct settings_data *_settings ) {
+  for (int i  = 0; i < 6; i++) {
+    clocks_store_channel( &allChannels[i], &_settings->channels[i] );
+  }
+}
+
+/* ------------------------------------------------------------------   */
+void clocks_restore( const struct settings_data *_settings ) {
+    for (int i  = 0; i < 6; i++) {
+      clocks_restore_channel( &allChannels[i], &_settings->channels[i] );
+    }
+}
 
 /*  -----------------  internal clock -------------------------------  */
 
@@ -557,6 +587,7 @@ void _wait()
   if (millis() - LAST_TRIG > CLK_LIMIT) _OK = true;
   
 }
+
 
 
 

--- a/soft/temps_utile/menu.ino
+++ b/soft/temps_utile/menu.ino
@@ -322,9 +322,13 @@ String makedisplay(uint16_t _channel, uint16_t _mode, uint16_t _param_slot) {
             else displaystring = String(paramval); 
             break;
          } // random
-         case _CLOCK_DIV: { 
-            if (_param_slot == 2) displaystring = String(yesno[paramval]);
-            else displaystring = String(paramval); 
+         case _CLOCK_DIV: {
+            switch(_param_slot) {
+              case 1: displaystring = String(paramval+1); break;
+              case 2: displaystring = String(yesno[paramval]); break;
+              default:
+                displaystring = String(paramval);
+            }
             break;
          } // clock div
          case _EUCLID: { 

--- a/soft/temps_utile/pagestorage.h
+++ b/soft/temps_utile/pagestorage.h
@@ -121,9 +121,12 @@ public:
     uint8_t *dst = (uint8_t*)&page_.data;
     size_t length = sizeof(DATA_TYPE);
     while (length--) {
-      if (*dst != *src)
+      if (*dst != *src) {
         dirty = true;
-      *dst++ = *src++;
+        *dst = *src;
+      }
+      ++dst;
+      ++src;
     }
 
     if (dirty) {

--- a/soft/temps_utile/pagestorage.h
+++ b/soft/temps_utile/pagestorage.h
@@ -1,0 +1,135 @@
+#ifndef PAGESTORAGE_H_
+#define PAGESTORAGE_H_
+
+/**
+ * Helper to save settings (in EEPROM)
+ * Divides the available space into fixed-length pages, so we can use a very
+ * basic wear-levelling to write pages in a different location each time.
+ * EEPROM only has a limited number of (reliable) write cycles so this helps
+ * to increase the usable time. Also, the page is only updated when the
+ * contents have changed.
+ *
+ * The "newest" version is identified as the page with the highest generation
+ * number; this is an uint32_t so should be safe for a while. A very simple
+ * CRC is used to check validity.
+ *
+ * Note that storage is uninitialized until ::load is called!
+ */
+template <size_t _BASE, size_t _LENGTH, size_t _PAGESIZE, typename _TYPE>
+class PageStorage {
+protected:
+ 
+  /**
+   * Binary page structure (aligned to uint16_t for CRC calculation)
+   */
+  struct page_data {
+    uint16_t checksum;
+    uint32_t generation;
+    uint32_t id;
+
+    _TYPE data;
+
+  } __attribute__((aligned(2)));
+
+public:
+  static const size_t BASE_ADDR = _BASE;
+  static const size_t LENGTH = _LENGTH;
+  static const size_t PAGESIZE = _PAGESIZE;
+  static const size_t PAGES = LENGTH / PAGESIZE;
+  static const uint32_t TYPEID = _TYPE::ID;
+  typedef _TYPE TYPE;
+  // throw compiler error if page size is too small
+  typedef page_data CHECK[ sizeof( page_data ) > PAGESIZE ? -1 : 1 ];
+
+  int page_index() const {
+    return _page_index;
+  }
+
+  /**
+   * Scan all pages to find the newest to load.
+   *
+   * @return true if data loaded
+   */
+  bool load( TYPE &_data ) {
+
+    _page_index = -1;
+    page_data next_page;
+    size_t pages = PAGES;
+    while ( pages-- ) {
+      int next = ( _page_index + 1 ) % PAGES;
+      EEPROM.get( BASE_ADDR + next * PAGESIZE, next_page );
+
+      if ( TYPEID != next_page.id )
+        break;
+      if ( next_page.checksum != checksum( next_page ) )
+          break;
+      if ( next_page.generation < page.generation )
+        break;
+
+      _page_index = next;
+      memcpy( &page, &next_page, sizeof( page ) );
+    }
+    
+    if ( -1 == _page_index ) {
+      memset( &page, 0, sizeof( page ) );
+      page.id = TYPEID;
+      return false;
+    } else {
+      memcpy( &_data, &page.data, sizeof( TYPE ) );
+      return true;
+    }
+  }
+
+  /**
+   * Save data to storage; assumes ::load has been called!
+   * @return true if actually stored
+   */
+  bool save( const TYPE &_data ) {
+
+    bool dirty = false;
+    const uint8_t *src = (const uint8_t*)&_data;
+    uint8_t *dst = (uint8_t*)&page.data;
+    size_t length = sizeof( TYPE );
+    while ( length-- ) {
+      dirty |= *dst != *src;
+      *dst++ = *src++;
+    }
+
+    if ( dirty ) {
+      ++page.generation;
+      page.checksum = checksum( page );
+      _page_index = ( _page_index + 1 ) % PAGES;
+
+      EEPROM.put( BASE_ADDR + _page_index * PAGESIZE, page );
+    }
+
+    return dirty;
+  }
+
+protected:
+
+  int _page_index;
+  page_data page;
+
+  uint16_t checksum( const page_data &_page ) {
+    uint16_t c = 0;
+    const uint16_t *p = (const uint16_t *)&_page;
+    // Don't include checksum itself in calculation
+    ++p;
+    size_t length = sizeof( page_data ) / sizeof( uint16_t ) - sizeof( uint16_t );
+    while ( length-- ) {
+      c += *p++;
+    }
+
+    return c ^ 0xffff;
+  }
+};
+
+template <uint32_t _1, uint32_t _2, uint32_t _3, uint32_t _4>
+struct FOURCC
+{
+  static const uint32_t value = ((_1&0xff) << 24) | ((_2&0xff) << 16) | ((_3&0xff) << 8) | (_4&0xff);
+};
+
+#endif // PAGESTORAGE_H_
+

--- a/soft/temps_utile/temps_utile.ino
+++ b/soft/temps_utile/temps_utile.ino
@@ -123,13 +123,13 @@ struct channel_settings {
 // Saved settings
 struct settings_data {
   // If contents of this struct changes, modify this identifier
-  static const uint32_t FOURCC = FOURCC<'T','U',1,0>::value;
+  static const uint32_t FOURCC = FOURCC<'T','U',1,1>::value;
 
   uint16_t cv_dest_channel[5]; // See menu.ino
   int16_t cv_dest_param[5];
   uint8_t clk_src;
-  uint8_t bpm;
-  uint8_t bpm_sel;
+  uint16_t bpm;
+  uint8_t bpm_sel; // note: defined as uint16_t
 
   channel_settings channels[6];
 };

--- a/soft/temps_utile/temps_utile.ino
+++ b/soft/temps_utile/temps_utile.ino
@@ -123,7 +123,7 @@ struct channel_settings {
 // Saved settings
 struct settings_data {
   // If contents of this struct changes, modify this identifier
-  static const uint32_t FOURCC = FOURCC<'T','U',0,3>::value;
+  static const uint32_t FOURCC = FOURCC<'T','U',1,0>::value;
 
   uint16_t cv_dest_channel[5]; // See menu.ino
   int16_t cv_dest_param[5];
@@ -232,10 +232,10 @@ void setup(){
   if (!digitalRead(butL))  calibrate_main();
   /* init */
   init_clocks();
-  load_settings();
   init_menu();  
   //CORETIMER.priority(32);
   //CORETIMER.begin(BPM_ISR, BPM_MICROSEC); 
+  load_settings();
 }
 
 /*       ---------------------------------------------------------         */ 

--- a/soft/temps_utile/temps_utile.ino
+++ b/soft/temps_utile/temps_utile.ino
@@ -128,6 +128,9 @@ struct settings_data {
   uint16_t cv_dest_channel[5]; // See menu.ino
   int16_t cv_dest_param[5];
   uint8_t clk_src;
+  uint8_t bpm;
+  uint8_t bpm_sel;
+
   channel_settings channels[6];
 };
 
@@ -159,7 +162,6 @@ static PageStorage<EEPROMStorage, 0x0, 128, struct settings_data> storage;
 /* ------------------------------------------------------------------   */
 void save_settings() {
 
-  settings.clk_src = CLK_SRC;
   memcpy(settings.cv_dest_channel, CV_DEST_CHANNEL, sizeof(settings.cv_dest_channel));
   memcpy(settings.cv_dest_param, CV_DEST_PARAM, sizeof(settings.cv_dest_param));
 

--- a/soft/temps_utile/temps_utile.ino
+++ b/soft/temps_utile/temps_utile.ino
@@ -17,6 +17,8 @@
 #include <spi4teensy3_14.h>
 #include <u8g_teensy_14.h>
 #include <rotaryplus.h>
+#include <EEPROM.h>
+#include "pagestorage.h"
 
 /* clock outputs */
 #define CLK1 29
@@ -87,6 +89,9 @@ uint16_t volatile _reset;
 extern uint16_t button_states[];
 extern volatile uint16_t CLK_SRC; // internal / external 
 extern volatile uint16_t _OK;     // ext. clock ok?
+// Used by settings
+extern uint16_t CV_DEST_CHANNEL[];
+extern int16_t CV_DEST_PARAM[];
 
 void UI_timerCallback() 
 { 
@@ -103,6 +108,65 @@ const uint8_t numADC = 4;
 const uint16_t HALFSCALE = 512;
 uint16_t CV[numADC+1];
 const uint16_t THRESHOLD = 400;
+
+
+/*       ---------------------------------------------------------         */
+
+// To save space (and increase the number of write cycles) this only stores
+// the current mode's parameters; the rest will be set to defaults on restart
+struct channel_settings {
+  uint8_t mode;
+  uint16_t param[4]; // match per-channel part of struct params::param
+  uint8_t cvmod[5]; // must match struct params::cvmod
+} __attribute__((packed)); // 1 + 8 + 5 = 14
+
+// Saved settings
+struct settings_data {
+  // If contents of this struct changes, modify ID 
+  static const uint32_t ID = FOURCC<'T','U',0,2>::value;
+
+  uint16_t cv_dest_channel[5]; // See menu.ino
+  int16_t cv_dest_param[5];
+  uint8_t clk_src;
+  channel_settings channels[6];
+};
+
+static settings_data settings;
+static PageStorage<0x0, 2048, 128, struct settings_data> storage;
+// sizeof(settings_data) with overhead is just < 128 which gives 16 pages, which
+// increases write cycles x16. Save is triggered on TIMEOUT (6s) so this should be
+// Good Enough (tm)
+
+/* ------------------------------------------------------------------   */
+void save_settings() {
+
+  settings.clk_src = CLK_SRC;
+  memcpy( settings.cv_dest_channel, CV_DEST_CHANNEL, sizeof( settings.cv_dest_channel ) );
+  memcpy( settings.cv_dest_param, CV_DEST_PARAM, sizeof( settings.cv_dest_param ) );
+
+  clocks_store( &settings );
+
+  if ( storage.save( settings ) ) {
+    Serial.print("Saved settings to page ");
+    Serial.print(storage.page_index());
+    Serial.println(" ");
+  }
+}
+
+/* ------------------------------------------------------------------   */
+void load_settings() {
+  if ( storage.load( settings ) ) {
+
+    Serial.print("Restoring settings from page ");
+    Serial.print(storage.page_index());
+    Serial.println(" ");
+
+    CLK_SRC = settings.clk_src;
+    memcpy( CV_DEST_CHANNEL, settings.cv_dest_channel, sizeof( settings.cv_dest_channel ) );
+    memcpy( CV_DEST_PARAM, settings.cv_dest_param, sizeof( settings.cv_dest_param ) );
+    clocks_restore( &settings );
+  }
+}
 
 /*       ---------------------------------------------------------         */
 
@@ -147,6 +211,7 @@ void setup(){
   if (!digitalRead(butL))  calibrate_main();
   /* init */
   init_clocks();
+  load_settings();
   init_menu();  
   //CORETIMER.priority(32);
   //CORETIMER.begin(BPM_ISR, BPM_MICROSEC); 
@@ -182,7 +247,10 @@ void loop()
     coretimer();
     if (_bpm) {   _bpm = 0; next_clocks(); }  
     /* timeout ?*/
-    if (UI_MODE && (millis() - LAST_UI > TIMEOUT)) time_out(); // timeout UI
+    if (UI_MODE && (millis() - LAST_UI > TIMEOUT)) {
+      save_settings();
+      time_out(); // timeout UI
+    }
  
     coretimer();
     if (_bpm) {   _bpm = 0; next_clocks(); }  

--- a/soft/temps_utile/temps_utile.ino
+++ b/soft/temps_utile/temps_utile.ino
@@ -154,10 +154,10 @@ struct EEPROMStorage {
 };
 
 static settings_data settings;
-static PageStorage<EEPROMStorage, 0x0, 128, struct settings_data> storage;
+static PageStorage<EEPROMStorage, 0, 128, struct settings_data> storage;
 // sizeof(settings_data) with overhead is just < 128 which gives 16 pages, which
-// increases write cycles x16. Save is triggered on TIMEOUT (6s) so this should be
-// Good Enough (tm)
+// effectively increases write cycles x16. Since the save is triggered on TIMEOUT
+// (6s) so this should be Good Enough (tm)
 
 /* ------------------------------------------------------------------   */
 void save_settings() {

--- a/soft/temps_utile/x_UI.ino
+++ b/soft/temps_utile/x_UI.ino
@@ -382,12 +382,7 @@ void update_channel_params(void) {
 
 void update_channel_mode(struct params* _p, uint16_t _mode) {
   
-      _p->mode = _mode;
-      _p->mode_param_numbers   = _CHANNEL_PARAMS[_mode];
-      const uint16_t *_min_ptr = _CHANNEL_PARAMS_MIN[_mode];
-      const uint16_t *_max_ptr = _CHANNEL_PARAMS_MAX[_mode];
-      memcpy(_p->param_min, _min_ptr, sizeof(_p->param_min));
-      memcpy(_p->param_max, _max_ptr, sizeof(_p->param_max));
+      channel_set_mode(_p,_mode);
       // update menu
       encoder[LEFT].setPos(_mode);
       encoder[RIGHT].setPos(_p->param[_mode][0]);

--- a/soft/temps_utile/x_UI.ino
+++ b/soft/temps_utile/x_UI.ino
@@ -22,14 +22,6 @@ enum _button_states {
   
 };
 
-enum _BPM_SEL {
-  
-  _4TH, 
-  _8TH,
-  _16TH
-  
-};
-
 // encoders:
 
 void left_encoder_ISR() {
@@ -55,14 +47,9 @@ void update_ENC()  {
           if      (right_encoder_data < BPM_MIN)    { BPM = BPM_MIN;  encoder[RIGHT].setPos(BPM_MIN); }
           else if (right_encoder_data > bpm_max)    { BPM = bpm_max;  encoder[RIGHT].setPos(bpm_max); }
           else BPM = right_encoder_data; 
-          
-          switch (BPM_SEL) {
-            
-              case _4TH:  BPM_MICROSEC = BPM_microseconds_4th[BPM-BPM_MIN];  break;
-              case _8TH:  BPM_MICROSEC = BPM_microseconds_8th[BPM-BPM_MIN];  break;
-              case _16TH: BPM_MICROSEC = BPM_microseconds_16th[BPM-BPM_MIN]; break;
-              default: break;
-          }
+
+          bpm_set_microseconds();
+
           MENU_REDRAW = 1;   
           LAST_UI = millis();    
     }
@@ -75,15 +62,10 @@ void update_ENC()  {
            else if (left_encoder_data < _4TH)  { BPM_SEL = _4TH;  encoder[LEFT].setPos(BPM_SEL); } 
            else BPM_SEL = left_encoder_data;
            
-           if (BPM > BPM_MAX[BPM_SEL]) BPM_SEL--; 
+           if (BPM > BPM_MAX[BPM_SEL]) BPM_SEL--;
            
-           switch (BPM_SEL) {
-            
-              case _4TH:  BPM_MICROSEC =  BPM_microseconds_4th[BPM-BPM_MIN]; break;
-              case _8TH:  BPM_MICROSEC =  BPM_microseconds_8th[BPM-BPM_MIN]; break;
-              case _16TH: BPM_MICROSEC = BPM_microseconds_16th[BPM-BPM_MIN]; break;
-              default: break;
-           }
+           bpm_set_microseconds();
+
            MENU_REDRAW = 1;   
            LAST_UI = millis(); 
     }  


### PR DESCRIPTION
Settings are saved when the UI times out and goes back to the idle screen, and only if the values have changed. The latest commits now save the internal clock BPM settings, and initialize the number of parameters as well as min/max values after loading. That seems to be enough, but I might have missed some internals.

The loaded values aren't explicitly re-checked for plausibility or min/max, but this could be added.

At the expense of some uncessary writes, the ::save function can drop the dirty check and rely on the low-level ::update function to check that data needs to be written. This might make it a bit faster if it throws the timing off. There are also better solutions to the brute-force comparison, e.g. setting a dirty flag in the UI, but this seemed a bit invasive.

I've used https://github.com/PaulStoffregen/EEPROM locally.

Let me know how it goes :smiley:
