### PR TITLE
eliminate erroneous output of channels when MULT > 1...

### DIFF
--- a/soft/t_u_REV/APP_CLK.ino
+++ b/soft/t_u_REV/APP_CLK.ino
@@ -858,7 +858,9 @@ public:
          reset_counter_ = false;
          // finally, process trigger + output
          _output = gpio_state_ = process_clock_channel(_mode); // = either ON, OFF, or anything (DAC)
-         TU::OUTPUTS::setState(clock_channel, _output);
+         if (_triggered) {
+           TU::OUTPUTS::setState(clock_channel, _output);
+         }
      }
   
      /*


### PR DESCRIPTION
eliminate erroneous output of channels when MULT > 1 and no trigger has arrived
