### PR TITLE
Pulsewidth and Global division setting no longer saved in v1.3

### DIFF
--- a/soft/t_u_REV/APP_CLK.ino
+++ b/soft/t_u_REV/APP_CLK.ino
@@ -2342,7 +2342,7 @@ SETTINGS_DECLARE(Clock_channel, CHANNEL_SETTING_LAST) {
   { 0, 0, TU::kNumDelayTimes - 1, "latency", TU::Strings::trigger_delay_times, settings::STORAGE_TYPE_U8 },
   { CHANNEL_TRIGGER_NONE, 0, CHANNEL_TRIGGER_LAST, "reset/mute", reset_trigger_sources, settings::STORAGE_TYPE_U8 },
   { MULT_BY_ONE, 0, MULT_MAX, "mult/div", multipliers, settings::STORAGE_TYPE_U8 },
-  { 25, 0, PULSEW_MAX, "pulsewidth", TU::Strings::pulsewidth_ms, settings::STORAGE_TYPE_U8, VALID_IF(CHANNEL_SETTING_MODE, CLOCKMODE::DAC) },
+  { 25, 0, PULSEW_MAX, "pulsewidth", TU::Strings::pulsewidth_ms, settings::STORAGE_TYPE_U8 },
   { 0, 0, PHASEOFFSET_MAX, "phase %", NULL, settings::STORAGE_TYPE_U8 },
   // note that BPM is a channel setting, although it's a global value.
   // when recalling, we just grab the value for channel 0

--- a/soft/t_u_REV/TU_app_storage.cpp
+++ b/soft/t_u_REV/TU_app_storage.cpp
@@ -65,6 +65,7 @@ void AppStorage::CheckSlot(size_t slot_index)
 
   if (slot.header.version != app->storage_version) {
     SERIAL_PRINTLN("Slot %u: id=%04x -- version mismatch, expected %04x, got %04x", slot_index, slot.header.id, app->storage_version, slot.header.version);
+    return;
   }
 
   // Some apps might have variable length settings, so there might not be a

--- a/soft/t_u_REV/TU_apps.cpp
+++ b/soft/t_u_REV/TU_apps.cpp
@@ -208,6 +208,7 @@ bool AppSwitcher::LoadAppFromSlot(size_t slot_index, bool save_state)
   bool loaded = false;
   if (app_storage.LoadAppFromSlot(app, slot_index)) {
     set_current_app(app);
+    global_config.Apply();
     if (save_state) {
       global_state.last_slot_index = slot_index;
       SaveGlobalState();

--- a/soft/t_u_REV/TU_apps.cpp
+++ b/soft/t_u_REV/TU_apps.cpp
@@ -33,7 +33,7 @@
 #include "util/util_macros.h"
 
 static constexpr TU::App available_apps[] = {
-  INSTANTIATE_APP("CL", 0x0101, "6xclocks", CLOCKS),
+  INSTANTIATE_APP("CL", 0x0102, "6xclocks", CLOCKS),
 };
 
 static constexpr int NUM_AVAILABLE_APPS = ARRAY_SIZE(available_apps);

--- a/soft/t_u_REV/src/SH1106_128x64_driver.cpp
+++ b/soft/t_u_REV/src/SH1106_128x64_driver.cpp
@@ -33,6 +33,7 @@
 #ifdef DMA_PAGE_TRANSFER
 #include <DMAChannel.h>
 static DMAChannel page_dma;
+static bool page_dma_active = false;
 #endif
 #ifndef SPI_SR_RXCTR
 #define SPI_SR_RXCTR 0XF0


### PR DESCRIPTION
Hi,
I merged a fix by @patrickdowling for this issue (https://github.com/mxmxmx/temps_utile-/issues/51)
I started from latest version of this repos.
I do not know if the project is still maintained or the project have another active repos.

Bye,
Richard
